### PR TITLE
Add a 'disabledEvents' option

### DIFF
--- a/actions.js
+++ b/actions.js
@@ -4,6 +4,9 @@ const PacketHandlers = require("./handlers.js");
 const { Constants, Collection, Channel, DMChannel, Invite } = require("discord.js");
 
 module.exports = client => {
+
+	for (let event of client.options.disabledEvents) delete PacketHandlers[event];
+
 	if(client.voice) {
 		client.voice.onVoiceStateUpdate = function({ guild_id, session_id, channel_id, shardID }) {
 			let connection = this.connections.get(guild_id);
@@ -19,6 +22,7 @@ module.exports = client => {
 			connection.setSessionID(session_id);
 		}
 	}
+
 	client.ws.handlePacket = function(packet, shard) {
 		if(packet && PacketHandlers[packet.t]) {
 			shard.lastPacket = Date.now();

--- a/client.d.ts
+++ b/client.d.ts
@@ -13,7 +13,8 @@ declare module "discord.js-light" {
 		cachePresences?:boolean,
 		cacheRoles?:boolean,
 		cacheOverwrites?:boolean,
-		cacheEmojis?:boolean
+		cacheEmojis?:boolean,
+		disabledEvents?: Array<string>
 	}
 	interface ClientEvents {
 		rest:[{path:string,method:string,response:Promise<Buffer>}],

--- a/client.js
+++ b/client.js
@@ -14,7 +14,8 @@ Discord.Client = class Client extends Discord.Client {
 				cachePresences:false,
 				cacheRoles:false,
 				cacheOverwrites:false,
-				cacheEmojis:false
+				cacheEmojis:false,
+				disabledEvents: []
 			},
 			options
 		);


### PR DESCRIPTION
I know that intents are an upcoming feature to the discord API, but I feel like being able to disable specific events is still useful. For example, I have enabled the "GUILDS" intent, but I only listen to the "GUILD_CREATE" event in that intent group, my program wastes resources to process every incoming event that I don't listen to in the "GUILDS" intent group. Since the purpose of this library is to disable caching, there's no actual state managing for guilds if you disable the guild cache (same goes for other caches), so completely ignoring events like "GUILD_UPDATE" is okay. 

This PR adds a "disabledEvents" option in the `ClientOptions` - An array consisting of discord event names to be ignored. It iterates through the array in the function exported from the `actions.js` file and deletes all the specified events from the `PacketHandlers` object. I've also updated the typings file.