### PR TITLE
types(ChannelManager|GuildChannelManager): removed unnecessary overload

### DIFF
--- a/client.d.ts
+++ b/client.d.ts
@@ -78,7 +78,6 @@ declare module "discord.js-light" {
 		fetch(options: GuildFetchOptions): Promise<Discord.Collection<Discord.Snowflake, Discord.Guild>>
 	}
 	interface ChannelManager {
-		forge(id: Discord.Snowflake): Discord.DMChannel
 		forge(id: Discord.Snowflake, type?: "dm"): Discord.DMChannel
 		forge(id: Discord.Snowflake, type: "text"): Discord.TextChannel
 		forge(id: Discord.Snowflake, type: "voice"): Discord.VoiceChannel
@@ -92,7 +91,6 @@ declare module "discord.js-light" {
 		fetch(options: { id: Discord.Snowflake } & ChannelFetchOptions): Promise<Discord.Channel>
 	}
 	interface GuildChannelManager {
-		forge(id: Discord.Snowflake): Discord.TextChannel
 		forge(id: Discord.Snowflake, type?: "text"): Discord.TextChannel
 		forge(id: Discord.Snowflake, type: "voice"): Discord.VoiceChannel
 		forge(id: Discord.Snowflake, type: "category"): Discord.CategoryChannel


### PR DESCRIPTION
The overload on the line below each already accounts for the same return type, so marking the second argument as optional is enough. No need to have a separate overload with no second argument