### PR TITLE
Organize bots in table, add server count badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,52 +426,31 @@ You can also find me in [discord](https://discord.gg/BpeedKh) (Tim#2373)
 
 ## Bots using discord.js-light
 
-[Astrobot](https://top.gg/bot/astrobot)
-
-[Message Viewer](https://top.gg/bot/642052166982303754)
-
-[Helper](https://top.gg/bot/409538753997307915)
-
-[Art Prompts](https://eledris.com/art-prompts/discord-bot/)
-
-[Xeno](https://github.com/NathanPenwill/Xeno/)
-
-[Tamaki](https://top.gg/bot/716322665283059754)
-
-[Animal Bot](https://top.gg/bot/716061781172158464)
-
-[Denky](https://denkybot.ga/)
-
-[Game Tracker](https://game-tracker.js.org/)
-
-[D-Safe](https://discordsafe.com/)
-
-[Aeon](https://aeon.js.org/)
-
-[Filo](https://filobot.xyz)
-
-[T_Moderator_Bot](https://top.gg/bot/412003088732389396)
-
-[T_Music_Bot](https://top.gg/bot/421978090823090186)
-
-[CalcBot](https://top.gg/bot/674457690646249472)
-
-[Infinity](https://top.gg/bot/545926934886875139)
-
-[Scathach](https://discord.bots.gg/bots/724047481561809007)
-
-[Music Boat](https://topcord.xyz/bot/735963752259911752)
-
-[Melody](https://melodybot.tk/)
-
-[Hydra bot](https://hydrabot.xyz/)
-
-[Multipurpose+](https://music.udit.gq/)
-
-[CleverChat](https://top.gg/bot/781834206325243954)
-
-[Dio](https://top.gg/bot/565050363313389588)
-
-[Bump Reminder](https://top.gg/bot/735147814878969968)
+| Bot | Servers |
+|-|-|
+| [Dio](https://top.gg/bot/565050363313389588) | ![](https://top.gg/api/widget/servers/565050363313389588.svg) |
+| [D-Safe](https://discordsafe.com/) | ![](https://top.gg/api/widget/servers/461171501715161108.svg) |
+| [Filo](https://filobot.xyz) | ![](https://top.gg/api/widget/servers/568083171455795200.svg) |
+| [Astrobot](https://top.gg/bot/astrobot) | ![](https://top.gg/api/widget/servers/344272098488877057.svg) |
+| [Art Prompts](https://eledris.com/art-prompts/discord-bot/) | ![](https://top.gg/api/widget/servers/676880644076339228.svg) |
+| [Bump Reminder](https://top.gg/bot/735147814878969968) | ![](https://top.gg/api/widget/servers/735147814878969968.svg) |
+| [Helper](https://top.gg/bot/409538753997307915) | ![](https://top.gg/api/widget/servers/409538753997307915.svg) |
+| [CalcBot](https://top.gg/bot/674457690646249472) | ![](https://top.gg/api/widget/servers/674457690646249472.svg) |
+| [Scathach](https://discord.bots.gg/bots/724047481561809007) | ![](https://top.gg/api/widget/servers/724047481561809007.svg) |
+| [Hydra bot](https://hydrabot.xyz/) | ![](https://top.gg/api/widget/servers/716708153143590952.svg) |
+| [Game Tracker](https://game-tracker.js.org/) | ![](https://top.gg/api/widget/servers/475421235950518292.svg) |
+| [Melody](https://melodybot.tk/) | ![](https://top.gg/api/widget/servers/739725994344316968.svg) |
+| [Animal Bot](https://top.gg/bot/716061781172158464) | ![](https://top.gg/api/widget/servers/716061781172158464.svg) |
+| [Denky](https://denkybot.ga/) | ![](https://top.gg/api/widget/servers/704517722100465746.svg) |
+| [T_Moderator_Bot](https://top.gg/bot/412003088732389396) | ![](https://top.gg/api/widget/servers/412003088732389396.svg) |
+| [Aeon](https://aeon.js.org/) | ![](https://top.gg/api/widget/servers/635833307510079490.svg) |
+| [Tamaki](https://top.gg/bot/716322665283059754) | ![](https://top.gg/api/widget/servers/716322665283059754.svg) |
+| [CleverChat](https://top.gg/bot/781834206325243954) | ![](https://top.gg/api/widget/servers/781834206325243954.svg) |
+| [T_Music_Bot](https://top.gg/bot/421978090823090186) | ![](https://top.gg/api/widget/servers/421978090823090186.svg) |
+| [Music Boat](https://topcord.xyz/bot/735963752259911752) | ![](https://top.gg/api/widget/servers/735963752259911752.svg) |
+| [Message Viewer](https://top.gg/bot/642052166982303754) | ![](https://top.gg/api/widget/servers/642052166982303754.svg) |
+| [Infinity](https://top.gg/bot/545926934886875139) |  |
+| [Multipurpose+](https://music.udit.gq/) |  |
+| [Xeno](https://github.com/NathanPenwill/Xeno/) |  |
 
 (using discord.js-light? let me know if you're interested in having your bot listed here)


### PR DESCRIPTION
I organized the list of bots using discord.js-light into a markdown table, with a column for their top.gg badge showing the bot's server counts, and ordered by popularity.

![image](https://user-images.githubusercontent.com/11231402/105613000-b007b880-5d8d-11eb-8b7e-473829747e2e.png)
