### PR TITLE
Added client options for sessionID and sequence arrays for hot reloading

### DIFF
--- a/client.js
+++ b/client.js
@@ -22,10 +22,25 @@ Discord.Client = class Client extends Discord.Client {
 		super(options);
 		actions(this);
 		if(options.hotreload) {
-			try {
-				this.ws._hotreload = JSON.parse(fs.readFileSync(`${process.cwd()}/.sessions.json`, "utf8"));
-			} catch(e) {
-				this.ws._hotreload = {};
+			this.ws._hotreload = {};
+			if (options.sessionID && options.sequence) {
+				if (!Array.isArray(options.sessionID) && !Array.isArray(options.sequence)) {
+					options.sessionID = [options.sessionID];
+					options.sequence = [options.sequence];
+				}
+				for (let shard = 0; shard < options.sessionID.length; shard++) {
+					this.ws._hotreload[shard] = {
+						id: options.sessionID[shard],
+						seq: options.sequence[shard]
+					};
+				}
+			}
+			else {
+				try {
+					this.ws._hotreload = JSON.parse(fs.readFileSync(`${process.cwd()}/.sessions.json`, "utf8"));
+				} catch(e) {
+					this.ws._hotreload = {};
+				}
 			}
 			for(const eventType of ["exit", "uncaughtException", "SIGINT", "SIGTERM"]) {
 				process.on(eventType, () => {


### PR DESCRIPTION
This pull request allows client options for `sessionID` and `sequence` so that users can define their own session resumes. Client options are not mandatory but take precedence over the local JSON file to avoid issues on containerised bots.

`options.sessionID` can be either an array of sessionID strings or a sessionID

`options.sequence` can be either an array of sequence number or a sequence

If using the array the index of that array refers to the shard that the session is going to be resumed under. I used arrays to match the format of [`clientOptions.shards`](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions)