### PR TITLE
Auto sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ The following client options are available to control caching behavior:
 | cachePresences | boolean | false | Enables caching of all Presences. If not enabled, Presences will be cached only for cached Users |
 | cacheMembers | boolean | false | Enables caching of Users and Members when possible |
 | disabledEvents | array | [] | An array of events to ignore ([Discord events](https://github.com/discordjs/discord.js/blob/master/src/util/Constants.js#L339), not Discord.JS events). Use this in combination with intents for fine tuning which events your bot should process |
+| channelSweepInterval | number | 0 | How frequently to remove channels from the cache that are older than the channel cache lifetime (in seconds, 0 for never) |
+| userSweepInterval | number | 0 | How frequently to remove users from the cache that are older than the user cache lifetime (in seconds, 0 for never) |
+| channelCacheLifetime | number | 86400 | How long a channel should stay in the cache until it is considered sweepable (in seconds, 0 for forever) |
+| userCacheLifetime | number | 86400 | How long a user should stay in the cache until it is considered sweepable (in seconds, 0 for forever) |
 
 This library implements its own partials system, therefore the `partials` client option is not available. All other discord.js client options continue to be available and should work normally.
 

--- a/client.d.ts
+++ b/client.d.ts
@@ -58,6 +58,10 @@ declare module "discord.js-light" {
 		cacheEmojis?: boolean
 		cacheMembers?: boolean
 		disabledEvents?: Array<string>
+		channelSweepInterval?: number
+		userSweepInterval?: number
+		channelCacheLifetime?: number
+		userCacheLifetime?: number
 	}
 	interface ClientEvents {
 		rest:[{path:string,method:string,response?:Promise<Buffer>}]

--- a/client.d.ts
+++ b/client.d.ts
@@ -50,13 +50,13 @@ type ReactionUserFetchOptions = {
 
 declare module "discord.js-light" {
 	interface ClientOptions {
-		cacheChannels?:boolean
-		cacheGuilds?:boolean
-		cachePresences?:boolean
-		cacheRoles?:boolean
-		cacheOverwrites?:boolean
-		cacheEmojis?:boolean
-		cacheMembers?:boolean
+		cacheChannels?: boolean
+		cacheGuilds?: boolean
+		cachePresences?: boolean
+		cacheRoles?: boolean
+		cacheOverwrites?: boolean
+		cacheEmojis?: boolean
+		cacheMembers?: boolean
 		disabledEvents?: Array<string>
 	}
 	interface ClientEvents {

--- a/client.js
+++ b/client.js
@@ -72,6 +72,12 @@ Discord.Client = class Client extends Discord.Client {
 				});
 			}
 		}
+		if (options.userSweepInterval > 0) {
+			this.setInterval(this.sweepUsers.bind(this), options.userSweepInterval * 1000);
+		}
+		if (options.channelSweepInterval > 0) {
+			this.setInterval(this.sweepChannels.bind(this), options.channelSweepInterval * 1000);
+		}
 	}
 	sweepUsers(_lifetime = this.options.userCacheLifetime) {
 		const lifetime = _lifetime * 1000;

--- a/client.js
+++ b/client.js
@@ -17,6 +17,10 @@ Discord.Client = class Client extends Discord.Client {
 			cacheEmojis: false,
 			cacheMembers: false,
 			disabledEvents: [],
+			channelCacheLifetime: 86400,
+			channelSweepInterval: 0,
+			userCacheLifetime: 86400,
+			userSweepInterval: 0,
 			..._options
 		};
 		super(options);

--- a/client.js
+++ b/client.js
@@ -79,20 +79,32 @@ Discord.Client = class Client extends Discord.Client {
 			this.setInterval(this.sweepChannels.bind(this), options.channelSweepInterval * 1000);
 		}
 	}
-	sweepUsers(_lifetime = this.options.userCacheLifetime) {
-		const lifetime = _lifetime * 1000;
-		this.users.cache.sweep(t => t.id !== this.user.id && (!t.lastMessageID || Date.now() - Discord.SnowflakeUtil.deconstruct(t.lastMessageID).timestamp > lifetime));
-		for(const guild of this.guilds.cache.values()) {
+
+	/**
+	 * Sweeps all cached Users and Members whose last message is older than the supplied time.
+	 * @param {number} lifetime User's last message's age in seconds. Defaults to 86400 (24 hours).
+	 * @returns {void}
+	 */
+	sweepUsers(lifetime = 86400) {
+		const _lifetime = lifetime * 1000;
+		this.users.cache.sweep(t => t.id !== this.user.id && (!t.lastMessageID || Date.now() - Discord.SnowflakeUtil.deconstruct(t.lastMessageID).timestamp > _lifetime));
+		for (const guild of this.guilds.cache.values()) {
 			guild.members.cache.sweep(t => !this.users.cache.has(t.id));
 			guild.presences.cache.sweep(t => !this.users.cache.has(t.id) && !this.options.cachePresences);
 		}
 	}
-	sweepChannels(_lifetime = this.options.channelCacheLifetime) {
-		const lifetime = _lifetime * 1000;
-		if(this.options.cacheChannels) { return; }
+
+	/**
+	 * Sweeps all cached Channels whose last message is older than the supplied time.
+	 * @param {number} lifetime Channel's last message's age in seconds. Defaults to 86400 (24 hours).
+	 * @returns {void}
+	 */
+	sweepChannels(lifetime = 86400) {
+		const _lifetime = lifetime * 1000;
+		if (this.options.cacheChannels) { return; }
 		const connections = this.voice ? this.voice.connections.map(t => t.channel.id) : [];
-		this.channels.cache.sweep(t => !connections.includes(t.id) && (!t.lastMessageID || Date.now() - Discord.SnowflakeUtil.deconstruct(t.lastMessageID).timestamp > lifetime));
-		for(const guild of this.guilds.cache.values()) {
+		this.channels.cache.sweep(t => !connections.includes(t.id) && (!t.lastMessageID || Date.now() - Discord.SnowflakeUtil.deconstruct(t.lastMessageID).timestamp > _lifetime));
+		for (const guild of this.guilds.cache.values()) {
 			guild.channels.cache.sweep(t => !this.channels.cache.has(t.id));
 		}
 	}

--- a/client.js
+++ b/client.js
@@ -73,7 +73,7 @@ Discord.Client = class Client extends Discord.Client {
 			}
 		}
 	}
-	sweepUsers(_lifetime = 86400) {
+	sweepUsers(_lifetime = this.options.userCacheLifetime) {
 		const lifetime = _lifetime * 1000;
 		this.users.cache.sweep(t => t.id !== this.user.id && (!t.lastMessageID || Date.now() - Discord.SnowflakeUtil.deconstruct(t.lastMessageID).timestamp > lifetime));
 		for(const guild of this.guilds.cache.values()) {
@@ -81,7 +81,7 @@ Discord.Client = class Client extends Discord.Client {
 			guild.presences.cache.sweep(t => !this.users.cache.has(t.id) && !this.options.cachePresences);
 		}
 	}
-	sweepChannels(_lifetime = 86400) {
+	sweepChannels(_lifetime = this.options.channelCacheLifetime) {
 		const lifetime = _lifetime * 1000;
 		if(this.options.cacheChannels) { return; }
 		const connections = this.voice ? this.voice.connections.map(t => t.channel.id) : [];


### PR DESCRIPTION
To be more in line with how discord.js handles automatic message sweeping for channel and user sweeps I added automatic setting of the interval if those client options are present.

Client options match vanilla discord.js [client options](https://discord.js.org/#/docs/main/stable/typedef/ClientOptions)