### PR TITLE
URGENT: Fixed broken reaction objects

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -48,7 +48,11 @@ function getOrCreateChannel(client, id, guild) {
 function getOrCreateMessage(channel, id) {
 	let message = channel.messages.cache.get(id);
 	if(!message) {
-		message = channel.messages._add({ id }, false); // nuilt in partial if content not a string
+		message = channel.messages._add({
+			id,
+			channel_id: channel.id,
+			guild_id: channel.guild?.id
+		}, false); // nuilt in partial if content not a string
 	}
 	return message;
 }


### PR DESCRIPTION
Currently, the `reaction` parameter in the `guildReactionAdd` and `guildReactionRemove` events return DMChannel channel types, `null` guild and `undefined` channelId (among all other missing data). This is due to the lack of information passed to `Base#_add`, which in turn doesn't set the corresponding `guildId` or `channelId` parameters to the message when creating it, trickling the lack of information down to the corresponding MessageReactions originating from the Message. I have added `channel_jd` and `guild_id` to correctly return the channel and guild from reactions. I'm not sure if there's anything else to add there, but I'm sure you know more than me about it.