### PR TITLE
Fixed import

### DIFF
--- a/extensions.js
+++ b/extensions.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { Collection } = require("@discordjs/collection");
+const Collection = require("@discordjs/collection");
 const { override, getOrCreateChannel, getOrCreateGuild } = require("./functions");
 
 override("/rest/APIRequest.js", X => class APIRequest extends X {


### PR DESCRIPTION
So I was using discord.js-light (v4.3.1) for creating a bot and I encountered an error stating "Collection is not a constructor":
`/home/four/Suggestions/node_modules/discord.js-light/extensions.js:28
                const roles = new Collection([[everyone.id, everyone]]);
                              ^

TypeError: Collection is not a constructor
    at GuildMemberRoleManager.get cache [as cache] (/home/four/Suggestions/node_modules/discord.js-light/extensions.js:28:17)
    at Client.<anonymous> (/home/four/Suggestions/app.js:90:47)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)

Node.js v17.1.0`

I then tried fixing it by altering the import statement and oddly enough it worked as expected without an error being thrown.